### PR TITLE
Un-deprecating stage ('names') {} 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,10 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# IntelliJ
+.idea/
+*.iml
+
+#VS Code
+.vscode/

--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ Sample testcases for Jenkins pipelines
 
 ## Notes
 
+### February 17, 2017
+
 When creating a stage, the use of parenthesis around the stage name, and curly braces around its body, as shown below,
-is the *proper* way. Doing so without is  deprecated, and you'll see this message in your console log:
+is the correct, current way. Doing so without is deprecated, and you'll see this message in your console log:
 
 Using the ‘stage’ step without a block argument is deprecated
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
+
 # pipeline-testcases
+
 Sample testcases for Jenkins pipelines
+
+## Notes
+
+When creating a stage, the use of parenthesis around the stage name, and curly braces around its body, as shown below,
+is the *proper* way. Doing so without is  deprecated, and you'll see this message in your console log:
+
+Using the ‘stage’ step without a block argument is deprecated
+
+The deprecated way of writing this stage would look like this:
+
+    stage "myFancyStageName"
+    echo "I just did something awesome."
+    node {
+        sh 'whoami'
+    }
+
+Same stage, written the new way:
+
+    stage ('myFancyStageName') {
+        echo "I just did something awesome."
+        node {
+            sh 'whoami'
+        }
+    }

--- a/benchmark-base-deprecated-stages.groovy
+++ b/benchmark-base-deprecated-stages.groovy
@@ -1,0 +1,44 @@
+// This is identical to benchmark-base.groovy, but with done
+// notable exception. I'm using the stage step without a block
+// argument. This was shown to be the root cause of JENKINS-42026.
+
+// Adding timestamps to the entire thing.
+timestamps {
+
+for (int i=0; i<15; i++) {
+
+    stage "Looping Stages $i" 
+        echo "My stage number is $i"        
+        node {
+            sh 'vmstat'
+        }
+    
+}
+
+// Run a basic shell step
+stage "Another shell script" 
+    node {
+        // Are we on something unix-y?
+        if (isUnix()) {
+            echo "Linux or other UNIX-y system detected."
+            sh 'vmstat'
+        }
+        // if not, we must be on windows.
+        else {
+            echo 'Windows system detected.'
+            bat "dir /ad"
+        }
+    }
+
+
+stage "Label-based" 
+    node {
+        stage ('Things using node') {
+            for (int i=0; i<20; i++) {
+                echo "We have done this $i times."    
+            }
+        }
+    }
+
+
+}

--- a/benchmark-base.groovy
+++ b/benchmark-base.groovy
@@ -4,39 +4,44 @@
 // Intended to be fairly fast to run (a few seconds) but load down some of the pipeline internals like a much larger pipeline
 
 for (int i=0; i<15; i++) {
-    stage "stage $i" 
-    echo "ran my stage is $i"        
-    node {
-        echo 'whoami';
+
+    stage ("stage $i") {
+        echo "ran my stage is $i"        
+        node {
+            sh 'whoami'
+        }
     }
 }
 
 // Run a basic shell step
-stage 'shellscript'
-node {
-    // Are we on something unix-y?
-    if (isUnix()) {
-        echo "Linux or other UNIX-y system detected."
-        sh 'whoami'
-    }
-    // if not, we must be on windows.
-    else {
-        echo 'Windows system detected.'
-        // Sample Windows bat commands:
-        //    bat "netstat -a"
-        // A powershell command with lots of output. Note the 
-        // escaped double quotes, otherwise you'll never see 
-        // the output:
-        //    bat "powershell.exe -command \"Get-WmiObject -Class Win32_Process\""
-        bat "dir /ad"
+stage ('shellscript') {
+    node {
+        // Are we on something unix-y?
+        if (isUnix()) {
+            echo "Linux or other UNIX-y system detected."
+            sh 'whoami'
+        }
+        // if not, we must be on windows.
+        else {
+            echo 'Windows system detected.'
+            // Sample Windows bat commands:
+            //    bat "netstat -a"
+            // A powershell command with lots of output. Note the 
+            // escaped double quotes, otherwise you'll never see 
+            // the output:
+            //    bat "powershell.exe -command \"Get-WmiObject -Class Win32_Process\""
+            bat "dir /ad"
+        }
     }
 }
 
-stage 'label based'
-echo 'wait for executor'
-node {
-    stage 'things using node'
-    for (int i=0; i<200; i++) {
-        echo "we waited for this $i seconds"    
+stage ('label based') {
+    echo 'wait for executor'
+    node {
+        stage ('things using node') {
+            for (int i=0; i<200; i++) {
+                echo "we waited for this $i seconds"    
+            }
+        }
     }
 }

--- a/benchmark-base.groovy
+++ b/benchmark-base.groovy
@@ -3,23 +3,26 @@
 // Represents a midsized-to-large pipeline (~315ish nodes), maps well to more complexish builds for normal users
 // Intended to be fairly fast to run (a few seconds) but load down some of the pipeline internals like a much larger pipeline
 
+// Adding timestamps to the entire thing.
+timestamps {
+
 for (int i=0; i<15; i++) {
 
-    stage ("stage $i") {
-        echo "ran my stage is $i"        
+    stage ("Looping Stages $i") {
+        echo "My stage number is $i"        
         node {
-            sh 'whoami'
+            sh 'vmstat'
         }
     }
 }
 
 // Run a basic shell step
-stage ('shellscript') {
+stage ('Another shell script') {
     node {
         // Are we on something unix-y?
         if (isUnix()) {
             echo "Linux or other UNIX-y system detected."
-            sh 'whoami'
+            sh 'vmstat'
         }
         // if not, we must be on windows.
         else {
@@ -35,13 +38,14 @@ stage ('shellscript') {
     }
 }
 
-stage ('label based') {
-    echo 'wait for executor'
+stage ('Label-based') {
     node {
-        stage ('things using node') {
-            for (int i=0; i<200; i++) {
-                echo "we waited for this $i seconds"    
+        stage ('Things using node') {
+            for (int i=0; i<20; i++) {
+                echo "We have done this $i times."    
             }
         }
     }
+}
+
 }


### PR DESCRIPTION
Jesse rightly pointed out that the stage steps in benchmark-base were being created without a block argument. In other words, they needed parentheses around the stage name, and curly braces around their bodies. I fixed those in benchmark-base.

Pipeline still works with them written the old way - and is possibly what causes, or helps to cause, JENKINS-42026. So I fixed them. I've also made a note of that trick in the README, because using deprecated, but still functional, syntax in a script can be a pretty good test.